### PR TITLE
Update settings.py

### DIFF
--- a/adl_lrs/settings.py
+++ b/adl_lrs/settings.py
@@ -14,6 +14,9 @@ config.read(SETTINGS_DIR+'/settings.ini')
 # If you want to debug
 DEBUG = config.getboolean('debug', 'DEBUG')
 
+# Support proxy https (Ex: Amazon ALB)
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
 # Set these email values to send the reset password link
 # If you do not want this functionality just comment out the
 # Forgot Password? link in templates/registration/login.html


### PR DESCRIPTION
Correct detect https for Amazon ALB proxy.

I setup ALB with only https protocol. And the dockerimage of adl-lrs. The ````request.is_secure```` always return ````false```` with my setup, and its made the base url show incorrect url.

After use this setting, the page is working correct 